### PR TITLE
fix: studio waits for studio db to accept connections

### DIFF
--- a/scaleout/stackn/templates/studio-deployment.yaml
+++ b/scaleout/stackn/templates/studio-deployment.yaml
@@ -28,8 +28,8 @@ spec:
     spec:
       initContainers:
         - name: wait-for-db
-          image: busybox:1.28
-          command: ['sh', '-c', "sleep 20;until nslookup {{ .Release.Name }}-studio-db.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for studio-db; sleep 3; done && sleep 3"]
+          image: postgres
+          command: ['sh', '-c', 'until pg_isready --host={{ .Release.Name }}-studio-db.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local --port=5432; do echo waiting for database; sleep 2; done;']
           resources:
             limits:
               cpu: 100m


### PR DESCRIPTION
Studio had issues sometimes as pod was initialized before Postgres (in the studio-db pod) was ready to accept connections. Changed the init container to use pg_isready (checks if database is active) instead of nslookup (checks if pod is up and running).